### PR TITLE
fix: global.css not found error

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -60,6 +60,10 @@ RUN pnpm install
 
 # Copy the full application and build it.
 COPY --from=builder /app/out/full/ .
+
+# Ensure the UI package source files are available for the CSS import
+COPY --from=builder /app/packages/ui/src ./packages/ui/src
+
 RUN pnpm build
 
 # ============


### PR DESCRIPTION
fixes
```
1.102 boilerplate-frontend:build: 
1.166 boilerplate-frontend:build:    Creating an optimized production build ...
20.12 boilerplate-frontend:build: Failed to compile.
20.12 boilerplate-frontend:build: 
20.12 boilerplate-frontend:build: ./app/layout.tsx
20.12 boilerplate-frontend:build: Module not found: Can't resolve '@workspace/ui/globals.css'
```

when building dockerfile