### PR TITLE
Remove deployer instructions and update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,16 @@ RESTACK_ENGINE_MCP_ADDRESS=https://fb095f09f128.ngrok-free.app/mcp
 # Where to send the user after the OAuth flow finishes (the dashboard).
 # Defaults to http://localhost:3000 for local dev.
 # FRONTEND_URL=https://app.your-domain.com
+
+# Public URL of the slack-bot as seen from the user's browser. The frontend uses
+# this to build the "Add to Slack" button on /integrations/slack, and the backend
+# uses it to surface the install URL to the build agent. Usually the same value
+# as SLACK_HTTP_BASE_URL.
+#
+# IMPORTANT: NEXT_PUBLIC_* is baked into the Next.js bundle at BUILD time, not
+# read at runtime. After changing this in production, you must rebuild the
+# frontend image for the change to take effect.
+# NEXT_PUBLIC_SLACK_BOT_URL=https://slack.your-domain.com
+# Read by the backend (build-agent install_url generator). Falls back to
+# NEXT_PUBLIC_SLACK_BOT_URL when unset, then localhost:3002 for local dev.
+# SLACK_BOT_URL=https://slack.your-domain.com

--- a/apps/frontend/app/(dashboard)/integrations/slack/page.tsx
+++ b/apps/frontend/app/(dashboard)/integrations/slack/page.tsx
@@ -551,12 +551,6 @@ function NotConnectedCard({
             Add to Slack
           </Button>
         )}
-        <p className="text-xs text-muted-foreground max-w-sm text-center">
-          Requires the Slack bot to be running in HTTP mode with{" "}
-          <code className="text-xs">SLACK_CLIENT_ID</code> and{" "}
-          <code className="text-xs">SLACK_CLIENT_SECRET</code> configured.
-          See SETUP.md for details.
-        </p>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
- Remove unnecessary deployer instructions on Slack Integration page
- Add required `NEXT...` envs for slack-bot base url